### PR TITLE
fix(website): resolve v2 SSR preview entry

### DIFF
--- a/apps/website/project.json
+++ b/apps/website/project.json
@@ -43,7 +43,7 @@
       },
       "configurations": {
         "preview": {
-          "ssr": "src/entry.preview.tsx",
+          "ssr": true,
           "mode": "production"
         },
         "production": {

--- a/apps/website/vite.config.ts
+++ b/apps/website/vite.config.ts
@@ -2,6 +2,7 @@ import { qwikRouter } from '@qwik.dev/router/vite';
 import { qwikVite } from '@qwik.dev/core/optimizer';
 import { defineConfig } from 'vite';
 import tsconfigPaths from 'vite-tsconfig-paths';
+import { fileURLToPath } from 'node:url';
 import { recmaProvideComponents } from './recma-provide-components';
 import autoAPI from './auto-api';
 import { ShikiTransformer } from 'shiki';
@@ -46,6 +47,7 @@ export default defineConfig(async () => {
         },
         ssr: {
           outDir: '../../dist/apps/website/server',
+          input: fileURLToPath(new URL('./src/entry.preview.tsx', import.meta.url)),
         },
       }),
       tsconfigPaths({ root: '../../' }),


### PR DESCRIPTION
# What is it?
- Bug

# Description
Qwik v2's optimizer passes the raw `build.ssr` string straight to rollup without resolving it against vite's root, so `pnpm preview` fails with "Could not resolve entry module ./src/entry.preview.tsx". Workaround: let nx set `build.ssr = true` and point `qwikVite.ssr.input` at an absolute path.